### PR TITLE
Add intial nix support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,49 @@
+{ pkgs, lib, stdenv, fetchFromGitHub, makeWrapper }:
+stdenv.mkDerivation rec {
+  pname = "dzgui";
+  version = "0.1";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  runtimeDeps = with pkgs; [
+    curl
+    jq
+    python3
+    wmctrl
+    xdotool
+    gnome.zenity
+
+    ## Here we don't declare steam as a dependency because
+    ## we could either use the native or flatpack version
+    ## and also so this does not become a non-free package
+    # steam
+  ];
+
+  patchPhase = ''
+    sed -i \
+      -e 's|/usr/bin/zenity|${pkgs.gnome.zenity}/bin/zenity|' \
+      -e 's|2>/dev/null||' \
+      dzgui.sh
+  '';
+
+  installPhase = ''
+    install -Dm777 -T dzgui.sh $out/bin/.dzgui-unwrapped_
+    makeWrapper $out/bin/.dzgui-unwrapped_ $out/bin/dzgui \
+      --prefix PATH ':' ${lib.makeBinPath runtimeDeps}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/pronovic/banner";
+    description = "DayZ TUI/GUI server browser";
+    license = licenses.gpl3;
+
+    longDescription = ''
+      DZGUI allows you to connect to both official and modded/community DayZ
+      servers on Linux and provides a graphical interface for doing so.
+    '';
+
+    platforms = platforms.all;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1674211260,
+        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "DayZ TUI/GUI server browser";
+  inputs = { nixpkgs.url = "nixpkgs/nixos-unstable"; };
+  outputs = { self, nixpkgs, ... }:
+    let
+      # DayZ only runs on x86_64 systems
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in with pkgs; {
+      packages.${system} = {
+        default = self.packages.${system}.dzgui;
+        dzgui = pkgs.callPackage ./. { };
+      };
+
+      devShells.${system}.default =
+        mkShell { buildInputs = self.packages.${system}.default.runtimeDeps; };
+    };
+}


### PR DESCRIPTION
Adds a package definition and a basic flake.

Nix flake users should be able to complete the installation just running:

```shell
nix profile install github:aclist/dztui
```

I don't think there's much need for documentation on this other than that one command.
