### PR TITLE
feat(ci): Add workflow for pushing to Codeberg

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,18 @@
+name: Mirror to Codeberg
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  mirror-to-codeberg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        if: ${{ vars.GIT_REMOTE != '' }}
+        with:
+          target_repo_url: ${{ vars.GIT_REMOTE }}
+          ssh_private_key: ${{ secrets.GIT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
You'll need to set up 1 variable:

- `GIT_REMOTE` to `git@codeberg.org:aclist/dztui.git`

and 2 secrets:

- `GIT_SSH_PRIVATE_KEY` to a private key you generated. (I think that SSH key is better than using your `git` password as if this leaks you just disable the key.)
  - Don't forget to add the pubkey to codeberg.org so that it can connect.

This is the `codeberg.org` pubkey as I was able to get it. Probably a good idea to check if you have the same.