### PR TITLE
fix: use GLibUnix namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [6.0.2-beta.3] 2026-04-10
+## Fixed
+- Use GLibUnix namespace when setting up SIGINT handling
+
 ## [6.0.2-beta.3] 2026-01-26
 ## Fixed
 - Raise error correctly from module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [6.0.2-beta.3] 2026-04-10
+## [6.0.2-beta.4] 2026-04-10
 ## Fixed
 - Use GLibUnix namespace when setting up SIGINT handling
 

--- a/dzgui.sh
+++ b/dzgui.sh
@@ -2,7 +2,7 @@
 set -o pipefail
 
 src_path="$(readlink -e "$0")"
-version=6.0.2-beta.3
+version=6.0.2-beta.4
 
 #CONSTANTS
 aid=221100
@@ -626,10 +626,10 @@ fetch_helpers_by_sum(){
     [[ -f "$config_file" ]] && source "$config_file"
     declare -A sums
     sums=(
-        ["funcs"]="9c790def4f70b6d1b0ed604a2b87b0dc"
+        ["funcs"]="a823824ec835a7db836aaff0eccd3a50"
         ["query_v2.py"]="55d339ba02512ac69de288eb3be41067"
         ["servers.py"]="ed442c3aecf33f777d59dcf53650d263"
-        ["ui.py"]="d09b9d8bed3854efd51377289786c5ac"
+        ["ui.py"]="d00c37fd006fa8cfb7fd02a8505e67e0"
         ["vdf2json.py"]="2f49f6f5d3af919bebaab2e9c220f397"
         ["pefile.py"]="b452974a84bff1d821872fcebf59e380"
     )
@@ -1122,9 +1122,9 @@ calc_local_coords(){
 }
 initial_setup(){
     check_architecture
-    test_connection
-    fetch_helpers
-    varcheck
+#    test_connection
+#    fetch_helpers
+#    varcheck
     source "$config_file"
     lock
     legacy_vars

--- a/dzgui.sh
+++ b/dzgui.sh
@@ -1122,9 +1122,9 @@ calc_local_coords(){
 }
 initial_setup(){
     check_architecture
-#    test_connection
-#    fetch_helpers
-#    varcheck
+    test_connection
+    fetch_helpers
+    varcheck
     source "$config_file"
     lock
     legacy_vars

--- a/helpers/funcs
+++ b/helpers/funcs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o pipefail
-version="6.0.2-beta.3"
+version="6.0.2-beta.4"
 
 #CONSTANTS
 aid=221100

--- a/helpers/ui.py
+++ b/helpers/ui.py
@@ -39,7 +39,8 @@ locale.setlocale(locale.LC_ALL, "")
 
 import gi  # noqa E402
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, Gdk, GObject, Pango  # noqa E402
+gi.require_version("GLibUnix", "2.0")
+from gi.repository import Gtk, GLib, GLibUnix, Gdk, GObject, Pango  # noqa E402
 
 # https://bugzilla.gnome.org/show_bug.cgi?id=708676
 warnings.filterwarnings("ignore", ".*g_value_get_int", Warning)
@@ -4651,7 +4652,7 @@ class App(Gtk.Application):
         )
         self.win.add_accel_group(accel)
 
-        GLib.unix_signal_add(
+        GLibUnix.signal_add_full(
             GLib.PRIORITY_DEFAULT, signal.SIGINT, self._catch_sigint
         )
         Gtk.main()


### PR DESCRIPTION
Resolves #277

Unix signals were moved to the `GLibUnix` namespace in glib 2.0. However, interactions between different versions of PyGObject and glib2 on the system can lead to different deprecation warnings.

Ordinarily, the language bindings should translate calls to `GLib.unix_signal_add()` and `GLibUnix.signal_add_full()` behind the scenes. For example, `GLib.unix_signal_add()` and `GLibUnix.signal_add_full()`should be translated to `GLibUnix.signal_add()`, but in practice, PyGObject is not always in lock-step with the latest glib2 version on the system.

After testing on Debian, Fedora, Arch variants, and Steam Deck, the only reliable call that was consistent across versions was the older `GLibUnix.signal_add_full()`. In some cases, this may trigger a deprecation warning to use `GLibUnix.signal_add()`, but it does not seem to block functionality, whereas using `GLibUnix.signal_add()` can block functionality on some systems because it is non-existent. Normally, this is expected to trigger a deprecration warning or be translated by the language, but it leads to an AttributeError if the language bindings are not up to date.

Because PyGObject uses introspection against the system's glib, there will inherently be version drift here in the future as namespaces are changed. For a more portable solution, consider also packing the glib dependencies with the application; this would need to be done with Flatpak, since even pyinstaller can have these synch issues.

If this continues to be intractable in the short term, it may be necessary to drop the SIGINT handling, since it has a minimal impact on functionality but can block the whole application.