### PR TITLE
docs: add contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Introduction
+
+Thank you for your interest in DZGUI!
+
+This guide goes over development conventions and best practices for contributors.
+If you are a developer, you can skip to the end.
+
+# Requesting help
+
+If you encounter a problem with DZGUI, you can submit tickets on the GitHub
+(issue tracker)[https://github.com/aclist/dzgui-devel/issues] under the
+`troubleshooting` tag.
+
+# How can I help the project?
+
+There are several ways to help this project.
+1. Report bugs that you find
+2. Request features that you would like
+3. Contribute features and fixes to the codebase
+4. Contribute documentation to the project
+
+Before making any contribution, please read the `CODE_OF_CONDUCT.md` and act
+accordingly.
+
+## Submitting a ticket
+
+Navigate to the GitHub (issue tracker)[https://github.com/aclist/dzgui-devel/issues].
+From there, follow the onscreen prompts. You will be asked questions such as:
+
+- What version are you using?
+- What distribution are you using?
+- What is the issue that you found?
+- How can we reproduce the issue?
+
+You can also attach screenshots, logs, or other data that can help us.
+
+## Requesting a feature
+
+You can also request features via the same issue tracker. It is good practice to
+first search for your idea to see if a similar one has already been posted.
+If not, open a ticket where you describe your feature and its possible benefits.
+
+Please note that this is a community project, so it takes time for us to develop
+features. Putting in a feature request does not mean that it will be implemented,
+but we will do our best to support as many cool ideas as possible.
+
+## Contributing code or documentation
+
+If you would like to take ownership or assist with an issue on the issue tracker, or
+contribute a new change, please follow the guidelines below.
+
+Fork this repository and check out the code up to `prerelease/<latest-version>`.
+If there is no pending prerelease PR, you can base your changes off of
+the `testing` branch. You may later be asked to retarget your PR to the prerelease
+branch once a new one is made. This is because out-of-band PRs are consolidated into
+the next release before merging.
+
+The following naming conventions apply for PRs:
+- fix/<your-fix> - patch/hotfix branches
+- feat/<your-feature> - feature branches
+- doc/<your-doc-branch> - documentation branches
+- infra/<your-infra-branch> - infrastructure branches
+
+Implement your changes and test them locally. If they work you may
+open a merge request, and then we review your changes. If everything is OK, it
+will be merged to `prerelease/<latest-version>`, then `testing`, and after a live
+testing phase, to `stable` as well.
+
+It is recommended to follow
+(Conventional Commits)[https://www.conventionalcommits.org/en/v1.0.0/], as this
+integrates well with tooling and helps the project review your code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you are a developer, you can skip to the end.
 # Requesting help
 
 If you encounter a problem with DZGUI, you can submit tickets on the GitHub
-(issue tracker)[https://github.com/aclist/dzgui-devel/issues] under the
+(issue tracker)[https://github.com/aclist/dztui/issues] under the
 `troubleshooting` tag.
 
 # How can I help the project?
@@ -24,7 +24,7 @@ accordingly.
 
 ## Submitting a ticket
 
-Navigate to the GitHub (issue tracker)[https://github.com/aclist/dzgui-devel/issues].
+Navigate to the GitHub (issue tracker)[https://github.com/aclist/dztui/issues].
 From there, follow the onscreen prompts. You will be asked questions such as:
 
 - What version are you using?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,14 +46,10 @@ but we will do our best to support as many cool ideas as possible.
 
 ## Contributing code or documentation
 
-If you would like to take ownership or assist with an issue on the issue tracker, or
+If you would like to assist with an issue on the issue tracker or
 contribute a new change, please follow the guidelines below.
 
-Fork this repository and check out the code up to `prerelease/<latest-version>`.
-If there is no pending prerelease PR, you can base your changes off of
-the `testing` branch. You may later be asked to retarget your PR to the prerelease
-branch once a new one is made. This is because out-of-band PRs are consolidated into
-the next release before merging.
+Fork this repository and check out the code up to the `dzgui7` (development) branch.
 
 The following naming conventions apply for PRs:
 - fix/<your-fix> - patch/hotfix branches
@@ -61,11 +57,13 @@ The following naming conventions apply for PRs:
 - doc/<your-doc-branch> - documentation branches
 - infra/<your-infra-branch> - infrastructure branches
 
-Implement your changes and test them locally. If they work you may
+Implement your changes and test them locally. If they work, you may
 open a merge request, and then we review your changes. If everything is OK, it
-will be merged to `prerelease/<latest-version>`, then `testing`, and after a live
-testing phase, to `stable` as well.
+will be merged to `dzgui7`. After sufficient changes are consolidated into a new release,
+this branch will be tagged to a certain point in time and a binary release published.
 
 It is recommended to follow
-(Conventional Commits)[https://www.conventionalcommits.org/en/v1.0.0/], as this
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), as this
 integrates well with tooling and helps the project review your code.
+
+Please see DEVELOPERS.md for further details.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,8 @@ Please refer to the documentation for installation and setup instructions:
 
 Geolocation records from [DB-IP](https://db-ip.com) under [CC 4.0 license](https://creativecommons.org/licenses/by/4.0/)
 
-This tool uses [python-a2s](https://github.com/Yepoleb/python-a2s) and [dayzquery](https://github.com/Yepoleb/dayzquery) as submodules; licenses for these submodules can be found in the LICENSES file
-of the project root.
-
-Both the geolocation records and submodules listed above are not shipped with the source code, but are retrieved and assembled at runtime.
-
-Finally, executable versions of DZGUI shipped as release binaries are thin wrappers around the Python interpreter, and also retrieve and assemble the above dependencies at runtime on the end-user's
-machine, rather than using pre-compiled source code. Users wishing to review these dependencies can inspect the 'pyproject.toml' manifest in the project root.
+Executable versions of DZGUI published as release binaries ship with various runtime dependencies and the Python interpreter built in.
+Users wishing to review the licenses to these components can inspect the `LICENSE` file located in the release tarball.
 
 ## Disclaimer
 


### PR DESCRIPTION
Clerical PR to add missing CONTRIBUTING.md file from DZGUI 6 codebase. Some wording needs to be updated in a future PR to better reflect DZGUI 7 workflows.