### PR TITLE
fix: prevent stuck launch dialog when history file is missing

### DIFF
--- a/dzgui/managers/config.py
+++ b/dzgui/managers/config.py
@@ -55,8 +55,11 @@ class ConfigManager:
         self.update_config(Preferences.IP_LIST, ips)
 
     def update_history_file(self, fqip: str) -> None:
-        with open(self.prefs.paths.history, "r") as f:
-            ips = [line.rstrip() for line in f.readlines()]
+        try:
+            with open(self.prefs.paths.history, "r") as f:
+                ips = [line.rstrip() for line in f.readlines()]
+        except FileNotFoundError:
+            ips = []
 
         seen = set()
         ips.append(fqip)


### PR DESCRIPTION
### Summary

On a fresh install (before any server has been recorded to history), connecting to a server leaves the **"Waiting for DayZ to launch"** dialog stuck on screen permanently. The game launches and is fully playable, but the dialog never closes and its Cancel button is unresponsive, so the only way to dismiss it is to kill DZGUI.

### Root cause

Launch detection works correctly. The hang happens *after* the game is detected, during the post-launch cleanup that records the server to history:

```
_destroy_on_idle (managers/threading.py)
  -> _add_to_history_and_return (managers/connection.py)
    -> add_to_history (controllers/mc.py)
      -> update_history_file (managers/config.py)
        -> open(self.prefs.paths.history, "r")
FileNotFoundError: [Errno 2] No such file or directory: '.../dzg.history'
```

`update_history_file()` opens `dzg.history` in read mode without handling the case where the file does not yet exist. `dzg.history` is only created the first time it is *written*, so on a clean install the very first connection raises `FileNotFoundError`.

Because this exception is raised inside the `GLib.idle_add(_destroy_on_idle)` cleanup callback, it propagates out **before** the following line runs:

```python
if not self.destroy_first:
    self.destroy_dialog()   # never reached
```

so the modal wait dialog is orphaned and can never be closed from the UI.

### Reproduction

1. Remove (or start without) `${XDG_STATE_HOME}/dzgui/dzg.history`.
2. Launch DZGUI and connect to any server.
3. The game starts, but the "Waiting for DayZ to launch" dialog stays up forever; Cancel does nothing.

`journalctl --user` shows the `FileNotFoundError` traceback at the moment the game is detected.

### Fix

Treat a missing history file as an empty history in `update_history_file()`, so the first-ever connection records history normally instead of crashing the cleanup callback. Minimal, localized change; no behavior change once the file exists.

### Testing

- Deleted `dzg.history`, connected to a server: the dialog now closes on launch as expected and `dzg.history` is created with the joined server.
- With an existing `dzg.history`, behavior is unchanged (history still deduplicates and caps at 10 entries).
