### PR TITLE
chore: test deferring maximize call until after widget is realized

### DIFF
--- a/dzgui/views/base.py
+++ b/dzgui/views/base.py
@@ -54,9 +54,8 @@ class OuterWindow(Gtk.Window):
         MainController.register_widget("window", self)
 
         # NOTE: steam deck taskbar may occlude elements
-        if MainController.get_prefs().is_steam_deck:
-            self.maximize()
-        else:
+        is_deck = MainController.get_prefs().is_steam_deck
+        if not is_deck:
             self.set_titlebar(self.hb)
 
         self.connect("delete-event", self._on_delete_event)
@@ -67,6 +66,8 @@ class OuterWindow(Gtk.Window):
         MainController.set_resolution(self)
         self.show_all()
         css.load_css()
+        if is_deck:
+            self.maximize()
 
         MainController.open_page(NotebookPage.SERVERS)
         MainController.set_start_tab()


### PR DESCRIPTION
gtk_widget_size_allocate() may emit noisy warnings if trying to maximize a widget with size 0. This is despite the documentation stating:

> It’s permitted to call this function before showing a window, in which case the window will be maximized when it appears onscreen initially.